### PR TITLE
Add option to load hocon from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ for this.
 
 ## Usage
 
-```bash 
-hoconvert [input] [--yaml]
+```bash
+hoconvert [input | --file <path>] [--yaml]
 ```
 
 Either provide the hocon as first argument:
@@ -32,6 +32,12 @@ which leads to the following output:
 {
   "foo": "bar"
 }
+```
+
+You can also read the hocon from file:
+
+```bash
+hoconvert --file config.hocon
 ```
 
 Here is an example of a real-life Kubernetes problem as stated above:

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -6,8 +6,17 @@ use crate::error::Error;
 pub struct Converter;
 
 impl Converter {
-  pub fn run(hocon_string: &str, yaml: bool) -> Result<String, Error> {
+  pub fn process_string(hocon_string: &str, yaml: bool) -> Result<String, Error> {
     let hocon = HoconLoader::new().load_str(hocon_string)?.hocon()?;
+    Converter::run(hocon, yaml)
+  }
+
+  pub fn process_file(path: &str, yaml: bool) -> Result<String, Error> {
+    let hocon = HoconLoader::new().load_file(path)?.hocon()?;
+    Converter::run(hocon, yaml)
+  }
+
+  fn run(hocon: Hocon, yaml: bool) -> Result<String, Error> {
     let json = Converter::hocon_to_raw_json(hocon)?;
 
     let output = if yaml {


### PR DESCRIPTION
This PR adds ability to load the HOCON from file, which is necessary to process HOCON with includes, as mentioned in #5.

Disclaimer: This is first code I have ever written in rust, so it might not be perfect on the first try :slightly_smiling_face:

I have tested on few non-trivial files and it seems to work fine. I did not add any new unit tests, since I only modified parts of code that were not covered by tests anyway. But I can try to add some if you think it is necessary.