### PR TITLE
Change processing of input

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for this.
 ## Usage
 
 ```bash
-hoconvert [input | --file <path>] [--yaml]
+hoconvert [input | --file <path>] [--output (yaml|json)]
 ```
 
 Either provide the hocon as first argument:
@@ -34,10 +34,10 @@ which leads to the following output:
 }
 ```
 
-You can also read the hocon from file:
+You can also read the hocon from a file by providing the path:
 
 ```bash
-hoconvert --file config.hocon
+hoconvert -f config.hocon
 ```
 
 Here is an example of a real-life Kubernetes problem as stated above:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,26 @@
+use clap::Parser;
+
+#[derive(clap::ValueEnum, Clone)]
+#[clap(rename_all = "lower")]
+pub(crate) enum Output {
+  Yaml,
+  Json,
+}
+
+/// Converts a hocon into JSON (default) or YAML.
+#[derive(Parser)]
+#[clap(version = "0.1.3", author = "Mathias Oertel <mathias.oertel@pm.me>")]
+pub(crate) struct Cli {
+  /// Has to be a valid HOCON representation. Provided either as first argument or from stdin.
+  #[clap(conflicts_with = "file")]
+  pub(crate) string: Option<String>,
+
+  /// File path to load the hocon for.
+  #[clap(long, short, conflicts_with = "string")]
+  pub(crate) file: Option<String>,
+
+  /// Option to speciy the output format.
+  #[clap(value_enum)]
+  #[clap(long, short, default_value = "json")]
+  pub(crate) output: Output,
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ pub(crate) struct Cli {
   #[clap(conflicts_with = "file")]
   pub(crate) string: Option<String>,
 
-  /// File path to load the hocon for.
+  /// File path to load the hocon from.
   #[clap(long, short, conflicts_with = "string")]
   pub(crate) file: Option<String>,
 

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -1,28 +1,27 @@
 use hocon::{Hocon, HoconLoader};
 use serde_json::{Map, Number, Value};
 
-use crate::error::Error;
+use crate::{error::Error, Output};
 
 pub struct Converter;
 
 impl Converter {
-  pub fn process_string(hocon_string: &str, yaml: bool) -> Result<String, Error> {
+  pub(crate) fn process_string(hocon_string: &str, output: Output) -> Result<String, Error> {
     let hocon = HoconLoader::new().load_str(hocon_string)?.hocon()?;
-    Converter::run(hocon, yaml)
+    Converter::run(hocon, output)
   }
 
-  pub fn process_file(path: &str, yaml: bool) -> Result<String, Error> {
+  pub(crate) fn process_file(path: &str, output: Output) -> Result<String, Error> {
     let hocon = HoconLoader::new().load_file(path)?.hocon()?;
-    Converter::run(hocon, yaml)
+    Converter::run(hocon, output)
   }
 
-  fn run(hocon: Hocon, yaml: bool) -> Result<String, Error> {
+  fn run(hocon: Hocon, output: Output) -> Result<String, Error> {
     let json = Converter::hocon_to_raw_json(hocon)?;
 
-    let output = if yaml {
-      serde_yaml::to_string(&json)?
-    } else {
-      serde_json::to_string_pretty(&json)?
+    let output = match output {
+      Output::Yaml => serde_yaml::to_string(&json)?,
+      Output::Json => serde_json::to_string_pretty(&json)?,
     };
 
     Ok(output)

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -1,22 +1,23 @@
+use crate::cli::Output;
+use crate::error::{Error, Result};
+
 use hocon::{Hocon, HoconLoader};
 use serde_json::{Map, Number, Value};
-
-use crate::{error::Error, Output};
 
 pub struct Converter;
 
 impl Converter {
-  pub(crate) fn process_string(hocon_string: &str, output: Output) -> Result<String, Error> {
+  pub(crate) fn process_string(hocon_string: &str, output: Output) -> Result<String> {
     let hocon = HoconLoader::new().load_str(hocon_string)?.hocon()?;
     Converter::run(hocon, output)
   }
 
-  pub(crate) fn process_file(path: &str, output: Output) -> Result<String, Error> {
+  pub(crate) fn process_file(path: &str, output: Output) -> Result<String> {
     let hocon = HoconLoader::new().load_file(path)?.hocon()?;
     Converter::run(hocon, output)
   }
 
-  fn run(hocon: Hocon, output: Output) -> Result<String, Error> {
+  fn run(hocon: Hocon, output: Output) -> Result<String> {
     let json = Converter::hocon_to_raw_json(hocon)?;
 
     let output = match output {
@@ -27,18 +28,18 @@ impl Converter {
     Ok(output)
   }
 
-  fn hocon_to_raw_json(hocon: Hocon) -> Result<Value, Error> {
+  fn hocon_to_raw_json(hocon: Hocon) -> Result<Value> {
     match hocon {
       Hocon::Boolean(b) => Ok(Value::Bool(b)),
       Hocon::Integer(i) => Ok(Value::Number(Number::from(i))),
       Hocon::Real(f) => Ok(Value::Number(Number::from_f64(f).unwrap())), // safe in this place, as we know that f is of type f64
       Hocon::String(s) => Ok(Value::String(s)),
       Hocon::Array(vec) => {
-        let json_array: Result<Vec<Value>, Error> = vec.into_iter().map(Converter::hocon_to_raw_json).collect();
+        let json_array: Result<Vec<Value>> = vec.into_iter().map(Converter::hocon_to_raw_json).collect();
         Ok(Value::Array(json_array?))
       }
       Hocon::Hash(map) => {
-        let json_object: Result<Map<String, Value>, Error> = map
+        let json_object: Result<Map<String, Value>> = map
           .into_iter()
           .map(|(k, v)| Ok((k, Converter::hocon_to_raw_json(v)?)))
           .collect();

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -3,6 +3,7 @@ use crate::error::{Error, Result};
 
 use hocon::{Hocon, HoconLoader};
 use serde_json::{Map, Number, Value};
+use std::path::Path;
 
 pub struct Converter;
 
@@ -13,8 +14,12 @@ impl Converter {
   }
 
   pub(crate) fn process_file(path: &str, output: Output) -> Result<String> {
-    let hocon = HoconLoader::new().load_file(path)?.hocon()?;
-    Converter::run(hocon, output)
+    if Path::new(path).try_exists()? {
+      let hocon = HoconLoader::new().load_file(path)?.hocon()?;
+      Converter::run(hocon, output)
+    } else {
+      Err(Error::PathNotFound(format!("Path '{path}' does not exist.")))
+    }
   }
 
   fn run(hocon: Hocon, output: Output) -> Result<String> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 
+pub type Result<T> = std::result::Result<T, Error>;
+
 #[derive(Debug)]
 pub enum Error {
   Hocon(hocon::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ pub enum Error {
   Json(serde_json::Error),
   Yaml(serde_yaml::Error),
   IO(std::io::Error),
+  PathNotFound(String),
 }
 
 impl std::error::Error for Error {}
@@ -20,6 +21,7 @@ impl fmt::Display for Error {
       Error::Json(e) => std::fmt::Display::fmt(e, f),
       Error::Yaml(e) => std::fmt::Display::fmt(e, f),
       Error::IO(e) => std::fmt::Display::fmt(e, f),
+      Error::PathNotFound(e) => std::fmt::Display::fmt(e, f),
     }
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,31 +8,39 @@ use crate::converter::Converter;
 mod converter;
 mod error;
 
-/// Converts a hocon into JSON (default) or YAML ('--yaml').
+#[derive(clap::ValueEnum, Clone)]
+#[clap(rename_all = "lower")]
+enum Output {
+  Yaml,
+  Json,
+}
+
+/// Converts a hocon into JSON (default) or YAML.
 #[derive(Parser)]
 #[clap(version = "0.1.3", author = "Mathias Oertel <mathias.oertel@pm.me>")]
-struct Opts {
-  /// Has to be a valid HOCON. Provided either as first argument or from stdin.
+struct Cli {
+  /// Has to be a valid HOCON representation. Provided either as first argument or from stdin.
   #[clap(conflicts_with = "file")]
-  hocon: Option<String>,
-  /// HOCON file to process.
-  #[clap(long, short, conflicts_with = "hocon")]
+  string: Option<String>,
+  /// File path to load the hocon for.
+  #[clap(long, short, conflicts_with = "string")]
   file: Option<String>,
-  /// Optional flag. If you want the output to be YAML.
-  #[clap(long, short)]
-  yaml: bool,
+  /// Option to speciy the output format.
+  #[clap(value_enum)]
+  #[clap(long, short, default_value = "json")]
+  output: Output,
 }
 
 fn main() -> Result<(), Error> {
-  let opts: Opts = Opts::parse();
+  let Cli { string, file, output } = Cli::parse();
 
-  let result = match (opts.hocon, opts.file) {
-    (Some(hocon), _) => Converter::process_string(&hocon, opts.yaml),
-    (_, Some(file)) => Converter::process_file(&file, opts.yaml),
+  let result = match (string, file) {
+    (Some(string), _) => Converter::process_string(&string, output),
+    (_, Some(file)) => Converter::process_file(&file, output),
     (None, None) => {
       let mut input_buffer = String::new();
       std::io::stdin().read_to_string(&mut input_buffer)?;
-      Converter::process_string(&input_buffer, opts.yaml)
+      Converter::process_string(&input_buffer, output)
     }
   };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,9 +22,11 @@ struct Cli {
   /// Has to be a valid HOCON representation. Provided either as first argument or from stdin.
   #[clap(conflicts_with = "file")]
   string: Option<String>,
+
   /// File path to load the hocon for.
   #[clap(long, short, conflicts_with = "string")]
   file: Option<String>,
+
   /// Option to speciy the output format.
   #[clap(value_enum)]
   #[clap(long, short, default_value = "json")]
@@ -44,5 +46,5 @@ fn main() -> Result<(), Error> {
     }
   };
 
-  result.map(|output| println!("{}", output))
+  result.map(|output| println!("{output}"))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,45 +1,21 @@
-use std::io::Read;
-
-use clap::Parser;
-use error::Error;
-
+use crate::cli::Cli;
 use crate::converter::Converter;
 
+use clap::Parser;
+use error::Result;
+use std::io::Read;
+
+mod cli;
 mod converter;
 mod error;
 
-#[derive(clap::ValueEnum, Clone)]
-#[clap(rename_all = "lower")]
-enum Output {
-  Yaml,
-  Json,
-}
-
-/// Converts a hocon into JSON (default) or YAML.
-#[derive(Parser)]
-#[clap(version = "0.1.3", author = "Mathias Oertel <mathias.oertel@pm.me>")]
-struct Cli {
-  /// Has to be a valid HOCON representation. Provided either as first argument or from stdin.
-  #[clap(conflicts_with = "file")]
-  string: Option<String>,
-
-  /// File path to load the hocon for.
-  #[clap(long, short, conflicts_with = "string")]
-  file: Option<String>,
-
-  /// Option to speciy the output format.
-  #[clap(value_enum)]
-  #[clap(long, short, default_value = "json")]
-  output: Output,
-}
-
-fn main() -> Result<(), Error> {
+fn main() -> Result<()> {
   let Cli { string, file, output } = Cli::parse();
 
   let result = match (string, file) {
     (Some(string), _) => Converter::process_string(&string, output),
     (_, Some(file)) => Converter::process_file(&file, output),
-    (None, None) => {
+    _ => {
       let mut input_buffer = String::new();
       std::io::stdin().read_to_string(&mut input_buffer)?;
       Converter::process_string(&input_buffer, output)

--- a/tests/yaml_feature.rs
+++ b/tests/yaml_feature.rs
@@ -8,7 +8,7 @@ use serde_yaml::Value;
 fn given_empty_hocon_when_convert_then_empty_yaml() {
   let mut cmd = Command::cargo_bin("hoconvert").unwrap();
 
-  let assert = cmd.arg("{}").arg("--yaml").assert();
+  let assert = cmd.arg("{}").arg("--output").arg("yaml").assert();
 
   let assert = assert.success();
   assert.stdout(predicate::str::contains("{}"));
@@ -18,7 +18,7 @@ fn given_empty_hocon_when_convert_then_empty_yaml() {
 fn given_empty_string_when_convert_then_empty_yaml() {
   let mut cmd = Command::cargo_bin("hoconvert").unwrap();
 
-  let assert = cmd.arg("").arg("--yaml").assert();
+  let assert = cmd.arg("").arg("--output").arg("yaml").assert();
 
   let assert = assert.success();
   assert.stdout(predicate::str::contains("{}"));
@@ -27,7 +27,7 @@ fn given_empty_string_when_convert_then_empty_yaml() {
 #[test]
 fn given_simple_key_value_when_convert_then_simple_yaml_object() {
   let mut cmd = Command::cargo_bin("hoconvert").unwrap();
-  let command = cmd.arg("foo = bar").arg("--yaml").assert();
+  let command = cmd.arg("foo = bar").arg("--output").arg("yaml").assert();
 
   let expected_yaml = r#"foo: "bar""#;
   let expected_yaml: Value = serde_yaml::from_str(expected_yaml).unwrap();
@@ -60,7 +60,11 @@ fn given_a_hocon_object_when_convert_then_reflected_in_yaml_object() {
 #[test]
 fn given_a_nested_hocon_object_when_convert_then_reflected_in_yaml_object() {
   let mut cmd = Command::cargo_bin("hoconvert").unwrap();
-  let command = cmd.arg("{ foo = { nested = { key = bar } } }").arg("--yaml").assert();
+  let command = cmd
+    .arg("{ foo = { nested = { key = bar } } }")
+    .arg("--output")
+    .arg("yaml")
+    .assert();
 
   let test_yaml = r#"
         foo:
@@ -79,7 +83,11 @@ fn given_a_nested_hocon_object_when_convert_then_reflected_in_yaml_object() {
 #[test]
 fn given_a_malformed_hocon_when_convert_then_error() {
   let mut cmd = Command::cargo_bin("hoconvert").unwrap();
-  let command = cmd.arg("{ foo = { nested = { key = bar ").arg("--yaml").assert();
+  let command = cmd
+    .arg("{ foo = { nested = { key = bar ")
+    .arg("--output")
+    .arg("yaml")
+    .assert();
 
   let assert = command.failure();
   assert.stderr(predicate::str::contains("Error: Hocon(Parse)"));
@@ -88,7 +96,7 @@ fn given_a_malformed_hocon_when_convert_then_error() {
 #[test]
 fn given_a_key_without_value_when_convert_then_error() {
   let mut cmd = Command::cargo_bin("hoconvert").unwrap();
-  let command = cmd.arg("{ foo = }").arg("--yaml").assert();
+  let command = cmd.arg("{ foo = }").arg("--output").arg("yaml").assert();
 
   let assert = command.failure();
   assert.stderr(predicate::str::contains("Error: Hocon(Parse)"));


### PR DESCRIPTION
As the option to parse form file path was added () a couple of small things were refactored. E.g. the `--yaml` flag which is now used as `-o|--output` option as it seems to be the standard (see `kubectl`, `helm` etc.).