### PR TITLE
chore(deps): update dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ license = "MIT"
 repository = "https://github.com/maoertel/hoconvert"
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 
 hocon = { git = "https://github.com/maoertel/hocon.rs", tag = "v0.10.0" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yml = "0.0.12"
-toml = "0.8"
+serde_yml = "0.0.13"
+toml = "1.1"
 
 [dev-dependencies]
 predicates = "3.1"
-assert_cmd = "2.1"
-serde_yml = "0.0.12"
-toml = "0.8"
+assert_cmd = "2.2"
+serde_yml = "0.0.13"
+toml = "1.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ pub(crate) struct Cli {
   #[clap(long, short, conflicts_with = "string")]
   pub(crate) file: Option<String>,
 
-  /// Option to speciy the output format.
+  /// Option to specify the output format.
   #[clap(value_enum)]
   #[clap(long, short, default_value = "json")]
   pub(crate) output: Output,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ mod error;
 fn main() -> Result<()> {
   let Cli { string, file, output } = Cli::parse();
 
-  // Use buffered stdout for better performance
   let stdout = io::stdout();
   let mut writer = BufWriter::new(stdout.lock());
 
@@ -26,7 +25,7 @@ fn main() -> Result<()> {
     }
   }?;
 
-  // Ensure trailing newline for cleaner terminal output
+  // Trailing newline for cleaner terminal output
   writeln!(writer)?;
   writer.flush()?;
 


### PR DESCRIPTION
## Summary

Updates all direct dependencies to their latest published versions. Build, clippy (`-D warnings`), and the full test suite are green.

## Changes

| Dependency | Before | After | Notes |
|------------|--------|-------|-------|
| `clap` | 4.5 | 4.6.1 | minor |
| `serde_json` | 1.0.149 | 1.0.150 | patch (lockfile) |
| `serde_yml` | 0.0.12 | 0.0.13 | manifest bump |
| `toml` | 0.8.23 | 1.1.2 | **major** — see below |
| `assert_cmd` (dev) | 2.1 | 2.2.2 | minor |
| `predicates` (dev) | 3.1.3 | 3.1.4 | patch (lockfile) |

Plus the corresponding transitive updates from `cargo update`.

### `toml` 0.8 → 1.1

This is a major version bump, but the serialization API used in this project is unaffected. All TOML conversion tests pass unchanged.

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 26 passed, 0 failed
- `cargo build` — success

## Also included

A small `docs` commit tidying comments (typo fix in `cli.rs`, trimming two redundant inline comments in `main.rs`). No behavior change.
