### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoconvert"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Mathias Oertel <mathias.oertel@pm.me>"]
 edition = "2024"
 description = "CLI tool to convert HOCON into valid JSON, YAML, or TOML."


### PR DESCRIPTION
## Summary

Bumps the crate version `1.1.0` → `1.1.1` for the next patch release, following the dependency updates in #20.

This patch release picks up the refreshed dependency tree (notably `toml` 1.1 and `clap` 4.6) with no functional changes to the CLI.