### PR TITLE
feat: migrate HOCON parser to hocon-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ predicates = "3.1"
 assert_cmd = "2.2"
 serde_yml = "0.0.13"
 toml = "1.1"
+criterion = "0.8"
+
+[[bench]]
+name = "parse"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/maoertel/hoconvert"
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }
 
-hocon = { git = "https://github.com/maoertel/hocon.rs", tag = "v0.10.0" }
+hocon-rs = "0.1"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,0 +1,81 @@
+//! Benchmarks for hoconvert's parse-and-convert pipeline.
+//!
+//! These mirror what `Converter` does: parse HOCON into a `serde_json::Value`
+//! with `hocon-rs`, then serialize to JSON, YAML, or TOML.
+
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use criterion::criterion_group;
+use criterion::criterion_main;
+
+use hocon_rs::Config;
+use serde_json::Value;
+
+/// A representative mid-size config exercising nesting, arrays of objects,
+/// substitutions, and value concatenation. Kept TOML-compatible (no nulls).
+const CONFIG: &str = r#"
+app {
+  name = "my-service"
+  version = "1.2.3"
+  debug = false
+  workers = 8
+  timeout-ms = 30000
+}
+server {
+  host = "0.0.0.0"
+  port = 8080
+}
+database {
+  host = "localhost"
+  port = 5432
+  pool { min = 2, max = 16 }
+  replicas = [
+    { host = "r1", port = 5433 },
+    { host = "r2", port = 5434 },
+    { host = "r3", port = 5435 }
+  ]
+}
+logging {
+  level = "info"
+  appenders = [console, file, syslog]
+}
+feature-flags {
+  a = true
+  b = false
+  c = ${app.debug}
+}
+"#;
+
+fn parse(input: &str) -> Value {
+  Config::parse_str::<Value>(input, None).expect("valid HOCON")
+}
+
+fn bench_parse(c: &mut Criterion) {
+  let mut group = c.benchmark_group("parse");
+  group.throughput(Throughput::Bytes(CONFIG.len() as u64));
+  group.bench_function("config", |b| b.iter(|| parse(CONFIG)));
+
+  for (name, input) in [
+    ("kv", "foo = bar"),
+    ("nested", "{ a = { b = { c = { d = 1 } } } }"),
+    ("array", "a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"),
+    ("substitution", "a = 1\nb = ${a}\nc = ${b}\nd = ${c}"),
+  ] {
+    group.bench_with_input(BenchmarkId::new("small", name), input, |b, i| b.iter(|| parse(i)));
+  }
+  group.finish();
+}
+
+fn bench_convert(c: &mut Criterion) {
+  let value = parse(CONFIG);
+
+  let mut group = c.benchmark_group("convert");
+  group.bench_function("json", |b| b.iter(|| serde_json::to_vec_pretty(&value).expect("json")));
+  group.bench_function("yaml", |b| b.iter(|| serde_yml::to_string(&value).expect("yaml")));
+  group.bench_function("toml", |b| b.iter(|| toml::to_string_pretty(&value).expect("toml")));
+  group.finish();
+}
+
+criterion_group!(benches, bench_parse, bench_convert);
+criterion_main!(benches);

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -1,37 +1,30 @@
 use crate::cli::Output;
 use crate::error::{Error, Result};
 
-use hocon::{Hocon, HoconLoader};
-use serde_json::{Map, Number, Value};
+use hocon_rs::Config;
+use serde_json::Value;
+use std::io::ErrorKind;
 use std::io::Write;
 
 pub struct Converter;
 
 impl Converter {
   pub(crate) fn process_string<W: Write>(hocon_string: &str, output: Output, writer: W) -> Result<()> {
-    let hocon = HoconLoader::new().load_str(hocon_string)?.hocon()?;
-    Converter::run(hocon, output, writer)
+    let value = Config::parse_str::<Value>(hocon_string, None)?;
+    Converter::run(value, output, writer)
   }
 
   pub(crate) fn process_file<W: Write>(path: &str, output: Output, writer: W) -> Result<()> {
-    let hocon = HoconLoader::new()
-      .load_file(path)
-      .map_err(|e| match e {
-        hocon::Error::Include { path } => Error::PathNotFound(format!("Path '{path}' does not exist.")),
-        other => Error::from(other),
-      })?
-      .hocon()?;
-    Converter::run(hocon, output, writer)
+    let value = Config::parse_file::<Value>(path, None).map_err(|e| Converter::map_file_error(path, e))?;
+    Converter::run(value, output, writer)
   }
 
-  fn run<W: Write>(hocon: Hocon, output: Output, mut writer: W) -> Result<()> {
-    let json = Converter::hocon_to_raw_json(hocon)?;
-
+  fn run<W: Write>(value: Value, output: Output, mut writer: W) -> Result<()> {
     match output {
-      Output::Yaml => serde_yml::to_writer(writer, &json)?,
-      Output::Json => serde_json::to_writer_pretty(writer, &json)?,
+      Output::Yaml => serde_yml::to_writer(writer, &value)?,
+      Output::Json => serde_json::to_writer_pretty(writer, &value)?,
       Output::Toml => {
-        let toml_str = toml::to_string_pretty(&json)?;
+        let toml_str = toml::to_string_pretty(&value)?;
         writer.write_all(toml_str.as_bytes())?;
       }
     };
@@ -39,30 +32,15 @@ impl Converter {
     Ok(())
   }
 
-  fn hocon_to_raw_json(hocon: Hocon) -> Result<Value> {
-    match hocon {
-      Hocon::Boolean(b) => Ok(Value::Bool(b)),
-      Hocon::Integer(i) => Ok(Value::Number(Number::from(i))),
-      Hocon::Real(f) => {
-        // Handle NaN and Infinity which can't be represented in JSON
-        Number::from_f64(f).map(Value::Number).ok_or(Error::InvalidFloat(f))
-      }
-      Hocon::String(s) => Ok(Value::String(s)),
-      Hocon::Array(vec) => {
-        let json_array: Result<Vec<Value>> = vec.into_iter().map(Converter::hocon_to_raw_json).collect();
-        Ok(Value::Array(json_array?))
-      }
-      Hocon::Hash(map) => {
-        let json_object: Result<Map<String, Value>> = map
-          .into_iter()
-          .map(|(k, v)| Ok((k, Converter::hocon_to_raw_json(v)?)))
-          .collect();
-
-        Ok(Value::Object(json_object?))
-      }
-      Hocon::Null => Ok(Value::Null),
-      Hocon::BadValue(bad_value) => Err(Error::from(bad_value)),
+  /// Map a missing top-level file to a friendly message; pass other errors through.
+  fn map_file_error(path: &str, error: hocon_rs::Error) -> Error {
+    if let hocon_rs::Error::Io(io_error) = &error
+      && io_error.kind() == ErrorKind::NotFound
+    {
+      return Error::PathNotFound(format!("Path '{path}' does not exist."));
     }
+
+    Error::from(error)
   }
 }
 
@@ -70,68 +48,70 @@ impl Converter {
 mod tests {
   use crate::cli::Output;
   use crate::converter::Converter;
-  use hocon::HoconLoader;
+
+  use serde_json::Value;
+  use serde_json::json;
+
+  fn to_value(input: &str) -> Value {
+    let mut output = Vec::new();
+    Converter::process_string(input, Output::Json, &mut output).unwrap();
+    serde_json::from_slice(&output).unwrap()
+  }
 
   #[test]
   fn empty_hocon_when_convert_empty_json() {
-    let hocon = "";
-    let hocon = HoconLoader::new().load_str(hocon).unwrap().hocon().unwrap();
-
-    let json = Converter::hocon_to_raw_json(hocon).unwrap();
-
-    let test_json = "{}";
-    let parsed_json = serde_json::to_string(&json).unwrap();
-    assert_eq!(test_json, parsed_json)
+    // Given an empty HOCON input
+    // When converting to JSON
+    // Then the result is an empty object
+    assert_eq!(to_value(""), json!({}));
   }
 
   #[test]
   fn simple_key_value_hocon_when_convert_reflected_in_json() {
-    let hocon = r#"foo = bar"#;
-    let hocon = HoconLoader::new().load_str(hocon).unwrap().hocon().unwrap();
-
-    let json = Converter::hocon_to_raw_json(hocon).unwrap();
-
-    let test_json = r#"{"foo":"bar"}"#;
-    let parsed_json = serde_json::to_string(&json).unwrap();
-    assert_eq!(test_json, parsed_json)
+    // Given a simple key/value HOCON
+    // When converting to JSON
+    // Then it reflects as a flat JSON object
+    assert_eq!(to_value(r#"foo = bar"#), json!({ "foo": "bar" }));
   }
 
   #[test]
   fn hocon_object_when_convert_reflected_in_json() {
-    let hocon = r#"{ foo = { key = bar } }"#;
-    let hocon = HoconLoader::new().load_str(hocon).unwrap().hocon().unwrap();
-
-    let json = Converter::hocon_to_raw_json(hocon).unwrap();
-
-    let test_json = r#"{"foo":{"key":"bar"}}"#;
-    let parsed_json = serde_json::to_string(&json).unwrap();
-    assert_eq!(test_json, parsed_json)
+    // Given a HOCON object
+    // When converting to JSON
+    // Then the nesting is preserved
+    assert_eq!(to_value(r#"{ foo = { key = bar } }"#), json!({ "foo": { "key": "bar" } }));
   }
 
   #[test]
   fn nested_hocon_object_when_convert_reflected_in_json() {
-    let hocon = r#"{ foo = { nested = { key = bar } } }"#;
-    let hocon = HoconLoader::new().load_str(hocon).unwrap().hocon().unwrap();
-
-    let json = Converter::hocon_to_raw_json(hocon).unwrap();
-
-    let test_json = r#"{"foo":{"nested":{"key":"bar"}}}"#;
-    let parsed_json = serde_json::to_string(&json).unwrap();
-    assert_eq!(test_json, parsed_json)
+    // Given a deeply nested HOCON object
+    // When converting to JSON
+    // Then the full nesting is preserved
+    assert_eq!(
+      to_value(r#"{ foo = { nested = { key = bar } } }"#),
+      json!({ "foo": { "nested": { "key": "bar" } } })
+    );
   }
 
   #[test]
   fn malformed_hocon_when_convert_returns_parse_error() {
-    let hocon = r#"{ foo = { nested = { key = bar"#;
-    let parse_error = HoconLoader::new().load_str(hocon).expect_err("This should fail");
+    // Given malformed HOCON
+    // When converting
+    // Then an error is returned
+    let mut output = Vec::new();
+    let result = Converter::process_string(r#"{ foo = { nested = { key = bar"#, Output::Json, &mut output);
 
-    assert_eq!(parse_error, hocon::Error::Parse)
+    assert!(result.is_err());
   }
 
   #[test]
   fn streaming_output_works() {
+    // Given a simple HOCON input
+    // When converting to JSON into a writer
+    // Then the streamed output contains the key and value
     let mut output = Vec::new();
     Converter::process_string(r#"foo = bar"#, Output::Json, &mut output).unwrap();
+
     let result = String::from_utf8(output).unwrap();
     assert!(result.contains("\"foo\""));
     assert!(result.contains("\"bar\""));
@@ -139,8 +119,12 @@ mod tests {
 
   #[test]
   fn toml_output_works() {
+    // Given a simple HOCON input
+    // When converting to TOML
+    // Then the output contains the key and value
     let mut output = Vec::new();
     Converter::process_string(r#"foo = bar"#, Output::Toml, &mut output).unwrap();
+
     let result = String::from_utf8(output).unwrap();
     assert!(result.contains("foo"));
     assert!(result.contains("bar"));

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,13 +5,12 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug)]
 pub enum Error {
-  Hocon(hocon::Error),
+  Hocon(hocon_rs::Error),
   Json(serde_json::Error),
   Yaml(serde_yml::Error),
   Toml(toml::ser::Error),
   IO(std::io::Error),
   PathNotFound(String),
-  InvalidFloat(f64),
 }
 
 impl std::error::Error for Error {}
@@ -25,16 +24,12 @@ impl fmt::Display for Error {
       Error::Toml(e) => std::fmt::Display::fmt(e, f),
       Error::IO(e) => std::fmt::Display::fmt(e, f),
       Error::PathNotFound(e) => std::fmt::Display::fmt(e, f),
-      Error::InvalidFloat(val) => write!(
-        f,
-        "Invalid float value: {val} (NaN or Infinity cannot be represented in JSON/TOML)"
-      ),
     }
   }
 }
 
-impl From<hocon::Error> for Error {
-  fn from(hocon_error: hocon::Error) -> Self {
+impl From<hocon_rs::Error> for Error {
+  fn from(hocon_error: hocon_rs::Error) -> Self {
     Error::Hocon(hocon_error)
   }
 }

--- a/tests/json_feature.rs
+++ b/tests/json_feature.rs
@@ -90,7 +90,7 @@ fn given_a_malformed_hocon_when_convert_then_error() {
   let command = cmd.arg("{ foo = { nested = { key = bar ").assert();
 
   let assert = command.failure();
-  assert.stderr(predicate::str::contains("Error: Hocon(Parse)"));
+  assert.stderr(predicate::str::contains("Error: Hocon("));
 }
 
 #[test]
@@ -99,5 +99,5 @@ fn given_a_key_without_value_when_convert_then_error() {
   let command = cmd.arg("{ foo = }").assert();
 
   let assert = command.failure();
-  assert.stderr(predicate::str::contains("Error: Hocon(Parse)"));
+  assert.stderr(predicate::str::contains("Error: Hocon("));
 }

--- a/tests/toml_feature.rs
+++ b/tests/toml_feature.rs
@@ -80,5 +80,5 @@ fn given_a_malformed_hocon_when_convert_then_error() {
     .assert();
 
   let assert = command.failure();
-  assert.stderr(predicate::str::contains("Error: Hocon(Parse)"));
+  assert.stderr(predicate::str::contains("Error: Hocon("));
 }

--- a/tests/yaml_feature.rs
+++ b/tests/yaml_feature.rs
@@ -90,7 +90,7 @@ fn given_a_malformed_hocon_when_convert_then_error() {
     .assert();
 
   let assert = command.failure();
-  assert.stderr(predicate::str::contains("Error: Hocon(Parse)"));
+  assert.stderr(predicate::str::contains("Error: Hocon("));
 }
 
 #[test]
@@ -99,5 +99,5 @@ fn given_a_key_without_value_when_convert_then_error() {
   let command = cmd.arg("{ foo = }").arg("--output").arg("yaml").assert();
 
   let assert = command.failure();
-  assert.stderr(predicate::str::contains("Error: Hocon(Parse)"));
+  assert.stderr(predicate::str::contains("Error: Hocon("));
 }


### PR DESCRIPTION
## Summary

Migrates hoconvert's HOCON parser from the git-pinned `maoertel/hocon.rs` fork to the crates.io-published [`hocon-rs`](https://crates.io/crates/hocon-rs), and adds criterion benchmarks.

**Why:** the git dependency on the fork blocks publishing hoconvert to crates.io (the registry rejects git deps). `hocon-rs` is on crates.io, is actively maintained, and — per a head-to-head evaluation — is faster and more spec-compliant.

## What changed

- **Dependency:** `hocon` (git) → `hocon-rs = "0.1"`.
- **`converter.rs`:** `hocon-rs` deserializes straight into `serde_json::Value`, so the manual `Hocon`-enum walker (`hocon_to_raw_json`) is **deleted**. The missing-top-level-file friendly message is preserved via a small error mapper.
- **`error.rs`:** `Hocon(hocon::Error)` → `Hocon(hocon_rs::Error)`; dropped the now-unreachable `InvalidFloat` variant (only the removed walker produced it).
- **Tests:** parse-error assertions relaxed from `Hocon(Parse)` (fork-specific) to the variant-agnostic `Hocon(` prefix, since `hocon-rs` reports `Eof` / `UnexpectedToken`. Unit tests rewritten to assert on converted output instead of the removed walker.
- **Benchmarks:** new `benches/parse.rs` (criterion) covering parse + serialize-to-each-format. Run with `cargo bench`.

## Correctness improvements (verified end-to-end)

The old fork had two spec bugs that this migration fixes:

| Input | old fork | hocon-rs (this PR) |
|---|---|---|
| `a = ${?UNDEFINED}` (optional substitution) | **errors** | field omitted → `{}` ✓ |
| `zip = 007` (leading zero) | `7` (int — data loss) | `"007"` (string) ✓ |

A broader 55-input differential test showed otherwise-identical output between the two parsers.

## Benchmarks: before (current `main`) vs after (this PR)

Measured with criterion in a single back-to-back run on the same machine, with **identical config and inputs**. "before" = current `main`: the `maoertel/hocon.rs` fork + the old manual `Hocon`→`serde_json::Value` walker. "after" = this PR: `hocon-rs` `Config::parse_str::<Value>`.

| Parse benchmark | before (`main`) | after (`hocon-rs`) | speedup |
|---|---|---|---|
| `config` (mid-size) | 55.0 µs | 17.9 µs | **3.1×** |
| `small/kv` | 2.06 µs | 0.71 µs | **2.9×** |
| `small/nested` | 5.47 µs | 2.44 µs | **2.2×** |
| `small/array` | 13.59 µs | 1.96 µs | **6.9×** |
| `small/substitution` | 8.42 µs | 2.46 µs | **3.4×** |

**Net: 2.2–6.9× faster parsing**, biggest win on arrays.

Serialization (`convert/json` ~0.93 µs, `convert/yaml` ~3.42 µs, `convert/toml` ~5 µs) is parser-independent — it runs on the same `serde_json::Value` either way — so it is unchanged by the migration.

<sub>The committed `benches/parse.rs` benchmarks the "after" pipeline. The "before" numbers were produced with the same config/inputs against `main`'s fork-based pipeline; that baseline harness isn't committed since `main` drops the fork once this merges.</sub>

## Notes / decisions

- **URL includes** were implicitly available through the fork's default features but are undocumented. They are **not** enabled here to keep the dependency tree lean (enabling them pulls the full `reqwest` + TLS stack). They can be restored with `hocon-rs`'s `urls_includes` feature if desired.
- `hocon-rs` is pre-1.0, so its API may still churn; the dependency is pinned to `0.1`.

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 26 passed, 0 failed
- `cargo build --release` — success
- Manual end-to-end smoke test across JSON/YAML/TOML + missing-file path
