### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoconvert"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Mathias Oertel <mathias.oertel@pm.me>"]
 edition = "2024"
 description = "CLI tool to convert HOCON into valid JSON, YAML, or TOML."


### PR DESCRIPTION
## Summary

Bumps the crate version `1.1.1` → `1.2.0` for the next release, following the parser migration in #22.

### Why minor (1.2.0)?

hoconvert is a CLI, so semver tracks the command-line surface (args/output), which is unchanged — no breaking change. But this release is more than a patch: it ships a **new HOCON parser backend** (`hocon-rs`) with spec-correctness improvements (optional substitutions `${?undefined}` now omit the field; leading-zero numbers like `007` stay strings) and is 2–7× faster at parsing. That's a minor bump.